### PR TITLE
fix accessing camel cased field names in Load

### DIFF
--- a/load.go
+++ b/load.go
@@ -66,6 +66,7 @@ func findPtr(column []string, value reflect.Value) ([]interface{}, error) {
 		var ptr []interface{}
 		m := structMap(value)
 		for _, key := range column {
+			key = camelCaseToSnakeCase(key)
 			if val, ok := m[key]; ok {
 				ptr = append(ptr, val.Addr().Interface())
 			} else {

--- a/load.go
+++ b/load.go
@@ -7,7 +7,6 @@ import (
 
 // Load loads any value from sql.Rows
 func Load(rows *sql.Rows, value interface{}) (int, error) {
-	defer rows.Close()
 
 	column, err := rows.Columns()
 	if err != nil {


### PR DESCRIPTION
Load was not behaving properly with camel cased field names without db tags: the tags were renamed from camel to snake case in [structValue](https://github.com/gocraft/dbr/blob/master/util.go#L62), but when findPtr [looked for a value in the resulting struct](https://github.com/gocraft/dbr/blob/master/load.go#L69), it did not do the same conversion.

An example struct where Load was failing:
`type Foo struct {
    FooBar       string `json:"FooBar"`
    BarFoo      string `json:"BarFoo"`
}`
