### PR TITLE
Camelcase fix in load

### DIFF
--- a/load.go
+++ b/load.go
@@ -66,6 +66,7 @@ func findPtr(column []string, value reflect.Value) ([]interface{}, error) {
 		var ptr []interface{}
 		m := structMap(value)
 		for _, key := range column {
+			key = camelCaseToSnakeCase(key)
 			if val, ok := m[key]; ok {
 				ptr = append(ptr, val.Addr().Interface())
 			} else {

--- a/load.go
+++ b/load.go
@@ -7,7 +7,6 @@ import (
 
 // Load loads any value from sql.Rows
 func Load(rows *sql.Rows, value interface{}) (int, error) {
-	defer rows.Close()
 
 	column, err := rows.Columns()
 	if err != nil {

--- a/load.go
+++ b/load.go
@@ -2,6 +2,7 @@ package dbr
 
 import (
 	"database/sql"
+	"fmt"
 	"reflect"
 )
 
@@ -45,6 +46,46 @@ func Load(rows *sql.Rows, value interface{}) (int, error) {
 	return count, nil
 }
 
+// Load loads string values from sql.Rows, allowing for potentially null values.
+func LoadNullStrings(rows *sql.Rows, value interface{}) (int, error) {
+
+	column, err := rows.Columns()
+	if err != nil {
+		return 0, err
+	}
+
+	v := reflect.ValueOf(value)
+	if v.Kind() != reflect.Ptr || v.IsNil() {
+		return 0, ErrInvalidPointer
+	}
+	v = v.Elem()
+	isSlice := v.Kind() == reflect.Slice && v.Type().Elem().Kind() != reflect.Uint8
+	count := 0
+	for rows.Next() {
+		var elem reflect.Value
+		if isSlice {
+			elem = reflect.New(v.Type().Elem()).Elem()
+		} else {
+			elem = v
+		}
+		ptr, err := findPtrNullString(column, elem)
+		if err != nil {
+			return 0, err
+		}
+		err = rows.Scan(ptr...)
+		if err != nil {
+			return 0, err
+		}
+		count++
+		if isSlice {
+			v.Set(reflect.Append(v, elem))
+		} else {
+			break
+		}
+	}
+	return count, nil
+}
+
 type dummyScanner struct{}
 
 func (dummyScanner) Scan(interface{}) error {
@@ -55,6 +96,20 @@ var (
 	dummyDest   sql.Scanner = dummyScanner{}
 	typeScanner             = reflect.TypeOf((*sql.Scanner)(nil)).Elem()
 )
+
+func findPtrNullString(column []string, value reflect.Value) ([]interface{}, error) {
+	var ptr []interface{}
+	m := structMap(value)
+	for _, key := range column {
+		key = camelCaseToSnakeCase(key)
+		if val, ok := m[key]; ok {
+			ptr = append(ptr, &sql.NullString{String: val.String(), Valid: true})
+		} else {
+			return []interface{}{}, fmt.Errorf("Key %s not present in structMap", key)
+		}
+	}
+	return ptr, nil
+}
 
 func findPtr(column []string, value reflect.Value) ([]interface{}, error) {
 	if value.Addr().Type().Implements(typeScanner) {


### PR DESCRIPTION
Add load function for null strings, to avoid having to use sql.NullString in all type declarations.
